### PR TITLE
Heroku deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Slackbot that reminds the team to do their periodic pushups.
 
 ![pushupbot: @channel time for pushups! Next pushups in 60 minutes.](.images/pushupbot-in-action.png "pushup-bot in action")
 
+## Deployment
+
+Built in Ruby. Can be deployed to Heroku or similar infrastructure.
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Running
 
 The following environment variables are used:
@@ -19,10 +25,6 @@ The following environment variables are used:
 - `ACTIVE_WEEKDAYS`: List of weekdays that notices will be sent. Default is "MTWRF", possible values "MTWRFSU".
 - `SLACK_API_TOKEN`
 - `SLACK_CHANNEL`
-
-## Deployment
-
-Built in Ruby. Can be deployed to Heroku or similar infrastructure.
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,13 @@
 require 'rubygems'
 require 'bundler/setup'
 
-  require 'dotenv'
-  Dotenv.load
 unless ENV['ENVIRONMENT'] == 'production'
+  begin
+    require 'dotenv'
+    Dotenv.load
+  rescue LoadError
+    ENV['ENVIRONMENT'] = 'production'
+  end
 end
 
 if ENV['ENVIRONMENT'] == 'production'

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 require 'rubygems'
 require 'bundler/setup'
 
-unless ENV['RAILS_ENV'] == 'production'
   require 'dotenv'
   Dotenv.load
+unless ENV['ENVIRONMENT'] == 'production'
 end
 
-if ENV['RAILS_ENV'] == 'production'
+if ENV['ENVIRONMENT'] == 'production'
   Bundler.require(:default)
 else
   Bundler.require(:default, :development)

--- a/app.json
+++ b/app.json
@@ -4,15 +4,18 @@
   "website": "https://github.com/omniboard/pushup-bot",
   "env": {
     "START_TIME": {
-      "description": "The time of day that the first pushups shall be done, including time zone. E.g. '09:25 US/Eastern'",
+      "description": "The time of day that the first pushups shall be done, including time zone.",
+      "value": "09:55 US/Eastern",
       "required": true
     },
     "PERIOD_MINUTES": {
-      "description": "The length of the period between sets.",
+      "description": "The length of the period between pushups, in minutes.",
+      "value": "120",
       "required": true
     },
     "END_TIME": {
-      "description": "No notices will be posted at or after this time. E.g. '17:30'",
+      "description": "No notices will be posted at or after this time.",
+      "value": "18:00",
       "required": true
     },
     "ACTIVE_WEEKDAYS": {
@@ -25,7 +28,7 @@
       "required": true
     },
     "SLACK_CHANNEL": {
-      "description": "Name of the channel to post to. Currently this bot is very narrow-minded and will only post here. You must invite them to the channel.",
+      "description": "Currently Pushup Bot is very narrow-minded and will only post to one channel. You must create this channel and invite the bot to it.",
       "required": true
     }
   },

--- a/app.json
+++ b/app.json
@@ -30,9 +30,6 @@
     "SLACK_CHANNEL": {
       "description": "Currently Pushup Bot is very narrow-minded and will only post to one channel. You must create this channel and invite the bot to it.",
       "required": true
-    },
-    "ENVIRONMENT": {
-      "value": "production"
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,38 @@
+{
+  "name": "Pushup Bot",
+  "description": "Slack Bot that says when it's time to do pushups",
+  "website": "https://github.com/omniboard/pushup-bot",
+  "env": {
+    "START_TIME": {
+      "description": "The time of day that the first pushups shall be done, including time zone. E.g. '09:25 US/Eastern'",
+      "required": true
+    },
+    "PERIOD_MINUTES": {
+      "description": "The length of the period between sets.",
+      "required": true
+    },
+    "END_TIME": {
+      "description": "No notices will be posted at or after this time. E.g. '17:30'",
+      "required": true
+    },
+    "ACTIVE_WEEKDAYS": {
+      "description": "List of weekdays that notices will be sent. All weekdays are 'UMTWRFS'.",
+      "value": "MTWRF",
+      "required": true
+    },
+    "SLACK_API_TOKEN": {
+      "description": "Real-time messaging API Token. Create a new bot here: https://slack.com/apps/new/A0F7YS25R-bots",
+      "required": true
+    },
+    "SLACK_CHANNEL": {
+      "description": "Name of the channel to post to. Currently this bot is very narrow-minded and will only post here. You must invite them to the channel.",
+      "required": true
+    }
+  },
+  "formation": {
+    "slackbot": {
+      "quantity": 1
+    }
+  },
+  "image": "heroku/ruby"
+}

--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
     "SLACK_CHANNEL": {
       "description": "Currently Pushup Bot is very narrow-minded and will only post to one channel. You must create this channel and invite the bot to it.",
       "required": true
+    },
+    "ENVIRONMENT": {
+      "value": "production"
     }
   },
   "formation": {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ require 'timecop'
 require 'pry'
 Bundler.require(:default, :test, :development)
 
-ENV['RAILS_ENV'] = "test"
+ENV['ENVIRONMENT'] = "test"
 
 WebMock.disable_net_connect! allow: 'api.codacy.com'
 


### PR DESCRIPTION
Add `app.json` needed for automated Heroku deployment, and add the button to the readme.

Fixed issue caused by the dotenv gem only being installed in production, but having no environment variable that indicates that (since this isn't a Rails app, Heroku doesn't add it automatically). Fixed this by assuming that if dotenv can't be loaded, we're in "production".